### PR TITLE
fix Subsequent variable declarations bust

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -62,6 +62,7 @@
     /* Experimental Options */
     // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
     // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+    ,"skipLibCheck": true
   },
   "include": ["./src/"],
   "exclude": ["**/*.test.ts"]


### PR DESCRIPTION
When building locally, some of us received the following error:
```sh
$ npm run build

> aws-azure-login@3.6.1 build /Users/kevin/Developer/mark43/aws-azure-login
> tsc

node_modules/@types/node/globals.d.ts:72:13 - error TS2403: Subsequent variable declarations must have the same type.  Variable 'AbortSignal' must be of type '{ new (): AbortSignal; prototype: AbortSignal; abort(reason?: any): AbortSignal; timeout(milliseconds: number): AbortSignal; }', but here has type '{ new (): AbortSignal; prototype: AbortSignal; }'.

72 declare var AbortSignal: {
               ~~~~~~~~~~~

  node_modules/typescript/lib/lib.dom.d.ts:2071:13
    2071 declare var AbortSignal: {
                     ~~~~~~~~~~~
    'AbortSignal' was also declared here.


Found 1 error in node_modules/@types/node/globals.d.ts:72

npm ERR! code ELIFECYCLE
npm ERR! errno 2
npm ERR! aws-azure-login@3.6.1 build: `tsc`
npm ERR! Exit status 2
npm ERR!
npm ERR! Failed at the aws-azure-login@3.6.1 build script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/kevin/.npm/_logs/2023-05-01T20_54_14_537Z-debug.log
```

Adding the following changes fixes the bust.